### PR TITLE
chore: input dynamic domain

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -87,7 +87,7 @@ runs:
       with:
         script: |
           const issue_number = context.payload.pull_request.number;
-          const message = `Deployment has finished 👁️👄👁️ Your app is available [here](https://${{ github.event.pull_request.base.repo.name }}-PR-${{ github.event.number }}.cleverapps.io)`;
+          const message = `Deployment has finished 👁️👄👁️ Your app is available [here](https://${{ inputs.domain }})`;
             github.rest.issues.createComment({
             owner: context.repo.owner,
             repo: context.repo.repo,
@@ -101,7 +101,7 @@ runs:
       with:
         script: |
           const issue_number = context.payload.pull_request.number;
-          const message = `🚀 You updated your review app. Check it [here](https://${{ github.event.pull_request.base.repo.name }}-PR-${{ github.event.number }}.cleverapps.io)`;
+          const message = `🚀 You updated your review app. Check it [here](https://${{ inputs.domain }})`;
             github.rest.issues.createComment({
             owner: context.repo.owner,
             repo: context.repo.repo,


### PR DESCRIPTION
Old script variable was still in `action.yaml`. This is not really a problem, since most users seem to use the default domain provided by the action, but since `domain` is an input, it should allow users to input a custom one if needed. 